### PR TITLE
Add copy-to-clipboard functionality to documentation code blocks

### DIFF
--- a/site/contribute/index.html
+++ b/site/contribute/index.html
@@ -12,6 +12,8 @@
     <script type="text/javascript" src="index.js"></script>
     <link rel="stylesheet" href="../style/guppy.css">
     <link rel="stylesheet" href="../index.css">
+    <link rel="stylesheet" href="../doc/copy-code.css">
+    <script type="text/javascript" src="../doc/copy-code.js"></script>
 
 </head>
 

--- a/site/doc/copy-code.css
+++ b/site/doc/copy-code.css
@@ -1,0 +1,50 @@
+/* Copy Code Button Styles */
+pre {
+    position: relative;
+}
+
+pre code {
+    display: block;
+}
+
+.copy-code-btn {
+    position: absolute;
+    top: 4px;
+    right: 8px;
+    padding: 6px;
+    background-color: rgba(255, 255, 255, 0.9);
+    color: #6b7280;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    z-index: 1000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+.copy-code-btn:hover {
+    background-color: #ffffff;
+    color: #374151;
+    border-color: rgba(0, 0, 0, 0.2);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.copy-code-btn:active {
+    transform: scale(0.95);
+}
+
+.copy-code-btn.copied {
+    color: #337ab7;
+    border-color: #5dabf0;
+}
+
+.copy-code-btn svg {
+    width: 18px;
+    height: 18px;
+    display: block;
+}

--- a/site/doc/copy-code.js
+++ b/site/doc/copy-code.js
@@ -1,0 +1,64 @@
+/**
+ * Add copy buttons to all code blocks on the page
+ */
+window.addEventListener('DOMContentLoaded', function() {
+    // Clipboard style icons
+    var copyIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path><rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect></svg>';
+    var checkIcon = '<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path><rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect><polyline points="10 13 12 15 16 9"></polyline></svg>';
+    
+    // Add copy buttons to all pre/code blocks
+    document.querySelectorAll('pre').forEach(function(pre) {
+        // Skip if button already exists
+        if (pre.querySelector('.copy-code-btn')) return;
+        
+        // Create copy button
+        var btn = document.createElement('button');
+        btn.className = 'copy-code-btn';
+        btn.innerHTML = copyIcon;
+        btn.setAttribute('aria-label', 'Copy code to clipboard');
+        btn.setAttribute('title', 'Copy code');
+        
+        btn.onclick = function(e) {
+            e.preventDefault();
+            var code = pre.querySelector('code') ? pre.querySelector('code').textContent : pre.textContent;
+            code = code.trim();
+            
+            navigator.clipboard.writeText(code).then(function() {
+                btn.innerHTML = checkIcon;
+                btn.classList.add('copied');
+                btn.setAttribute('title', 'Copied!');
+                setTimeout(function() {
+                    btn.innerHTML = copyIcon;
+                    btn.classList.remove('copied');
+                    btn.setAttribute('title', 'Copy code');
+                }, 2000);
+            }).catch(function(err) {
+                console.error('Failed to copy: ', err);
+                // Fallback for older browsers
+                var textArea = document.createElement('textarea');
+                textArea.value = code;
+                textArea.style.position = 'fixed';
+                textArea.style.left = '-999999px';
+                textArea.style.top = '-999999px';
+                document.body.appendChild(textArea);
+                textArea.select();
+                try {
+                    document.execCommand('copy');
+                    btn.innerHTML = checkIcon;
+                    btn.classList.add('copied');
+                    btn.setAttribute('title', 'Copied!');
+                    setTimeout(function() {
+                        btn.innerHTML = copyIcon;
+                        btn.classList.remove('copied');
+                        btn.setAttribute('title', 'Copy code');
+                    }, 2000);
+                } catch (err) {
+                    console.error('Copy command failed');
+                }
+                document.body.removeChild(textArea);
+            });
+        };
+        
+        pre.appendChild(btn);
+    });
+});

--- a/site/doc/faq.html
+++ b/site/doc/faq.html
@@ -12,6 +12,8 @@
     <script type="text/javascript" src="index.js"></script>
     <link rel="stylesheet" href="../style/guppy.css">
     <link rel="stylesheet" href="../index.css">
+    <link rel="stylesheet" href="copy-code.css">
+    <script type="text/javascript" src="copy-code.js"></script>
 
 </head>
 

--- a/site/doc/format.html
+++ b/site/doc/format.html
@@ -12,6 +12,8 @@
     <script type="text/javascript" src="index.js"></script>
     <link rel="stylesheet" href="../style/guppy.css">
     <link rel="stylesheet" href="../index.css">
+    <link rel="stylesheet" href="copy-code.css">
+    <script type="text/javascript" src="copy-code.js"></script>
 
 </head>
 

--- a/site/doc/index.html
+++ b/site/doc/index.html
@@ -12,6 +12,8 @@
     <script type="text/javascript" src="index.js"></script>
     <link rel="stylesheet" href="../style/guppy.css">
     <link rel="stylesheet" href="../index.css">
+    <link rel="stylesheet" href="copy-code.css">
+    <script type="text/javascript" src="copy-code.js"></script>
 
 </head>
 

--- a/site/doc/internals.html
+++ b/site/doc/internals.html
@@ -12,6 +12,8 @@
     <script type="text/javascript" src="index.js"></script>
     <link rel="stylesheet" href="../style/guppy.css">
     <link rel="stylesheet" href="../index.css">
+    <link rel="stylesheet" href="copy-code.css">
+    <script type="text/javascript" src="copy-code.js"></script>
 
 </head>
 

--- a/site/doc/quickstart.html
+++ b/site/doc/quickstart.html
@@ -12,6 +12,8 @@
     <script type="text/javascript" src="index.js"></script>
     <link rel="stylesheet" href="../style/guppy.css">
     <link rel="stylesheet" href="../index.css">
+    <link rel="stylesheet" href="copy-code.css">
+    <script type="text/javascript" src="copy-code.js"></script>
 
 </head>
 

--- a/site/doc/render.html
+++ b/site/doc/render.html
@@ -12,6 +12,8 @@
     <script type="text/javascript" src="index.js"></script>
     <link rel="stylesheet" href="../style/guppy.css">
     <link rel="stylesheet" href="../index.css">
+    <link rel="stylesheet" href="copy-code.css">
+    <script type="text/javascript" src="copy-code.js"></script>
 
 </head>
 

--- a/site/doc/roadmap.html
+++ b/site/doc/roadmap.html
@@ -12,6 +12,8 @@
     <script type="text/javascript" src="index.js"></script>
     <link rel="stylesheet" href="../style/guppy.css">
     <link rel="stylesheet" href="../index.css">
+    <link rel="stylesheet" href="copy-code.css">
+    <script type="text/javascript" src="copy-code.js"></script>
 
 </head>
 

--- a/site/doc/script.html
+++ b/site/doc/script.html
@@ -12,6 +12,8 @@
     <script type="text/javascript" src="index.js"></script>
     <link rel="stylesheet" href="../style/guppy.css">
     <link rel="stylesheet" href="../index.css">
+    <link rel="stylesheet" href="copy-code.css">
+    <script type="text/javascript" src="copy-code.js"></script>
 
 </head>
 

--- a/site/doc/style.html
+++ b/site/doc/style.html
@@ -12,6 +12,8 @@
     <script type="text/javascript" src="index.js"></script>
     <link rel="stylesheet" href="../style/guppy.css">
     <link rel="stylesheet" href="../index.css">
+    <link rel="stylesheet" href="copy-code.css">
+    <script type="text/javascript" src="copy-code.js"></script>
 
 </head>
 

--- a/site/doc/symbols.html
+++ b/site/doc/symbols.html
@@ -12,6 +12,8 @@
     <script type="text/javascript" src="index.js"></script>
     <link rel="stylesheet" href="../style/guppy.css">
     <link rel="stylesheet" href="../index.css">
+    <link rel="stylesheet" href="copy-code.css">
+    <script type="text/javascript" src="copy-code.js"></script>
 
 </head>
 

--- a/site/doc/version.html
+++ b/site/doc/version.html
@@ -12,6 +12,8 @@
     <script type="text/javascript" src="index.js"></script>
     <link rel="stylesheet" href="../style/guppy.css">
     <link rel="stylesheet" href="../index.css">
+    <link rel="stylesheet" href="copy-code.css">
+    <script type="text/javascript" src="copy-code.js"></script>
 
 </head>
 


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of **N/A** (new feature enhancement)
2. **This PR does the following:** Adds copy-to-clipboard buttons to all code blocks in documentation pages. Users can click a clipboard icon to instantly copy code examples. Includes visual feedback with checkmark and blue highlight on successful copy.
 

## Essential Checklist

- [x] I have followed the build process and verified changes work locally
- [x] The linter/Karma presubmit checks pass on my local machine
- [x] "Allow edits from maintainers" is checked
 

## Changes Made

**New Files:**
- `site/doc/copy-code.css` - Button styling with SVG clipboard icons
- `site/doc/copy-code.js` - Copy functionality with Clipboard API + fallback

**Modified Files:**
- Updated 12 documentation HTML files to include copy-code assets

**Total:** 14 files changed, 138+ lines added

## Implementation Details

- Pure vanilla JavaScript (zero dependencies)
- Modern Clipboard API with document.execCommand fallback
- Absolute positioning (top-right) to avoid code layout disruption
- Visual feedback: checkmark icon + blue highlight for 2 seconds
- SVG icons: clipboard outline → checkmark on success
- Works on all browsers (tested Chrome, Firefox, Safari)

## Testing

✅ Tested locally on http://127.0.0.1:8066  
✅ All 12 documentation pages working correctly  
✅ No console errors  
✅ Copy functionality verified  
✅ Visual feedback displays properly  
✅ Layout remains intact (no disruption)  

## Files Updated

1. site/doc/quickstart.html
2. site/doc/script.html
3. site/doc/style.html
4. site/doc/render.html
5. site/doc/symbols.html
6. site/doc/version.html
7. site/doc/format.html
8. site/doc/internals.html
9. site/doc/faq.html
10. site/doc/roadmap.html
11. site/doc/index.html
12. site/contribute/index.html

## Note

This PR only enhances documentation UX and doesn't modify Guppy's core functionality or package.json. Changes are isolated to static HTML documentation pages only.
 
<img width="1246" height="354" alt="Screenshot 2025-11-26 at 10 35 47 AM" src="https://github.com/user-attachments/assets/c043e376-2563-41e2-aa3b-c9c563122618" />
