### PR TITLE
Refactor rollup configuration to use modern plugins and improve struc…

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,34 +1,37 @@
-import commonjs from 'rollup-plugin-commonjs';
-import babel from 'rollup-plugin-babel';
-import { uglify } from 'rollup-plugin-uglify';
-import json from 'rollup-plugin-json';
+import commonjs from '@rollup/plugin-commonjs';
+import babel from '@rollup/plugin-babel';
+import json from '@rollup/plugin-json';
+import { terser } from '@rollup/plugin-terser';
+
+const isProd = process.env.NODE_ENV === 'production';
+const isTest = process.env.NODE_ENV === 'test';
+
+const outputFile = isProd
+  ? 'build/guppy.min.js'
+  : isTest
+  ? 'build/guppy-test.js'
+  : 'build/guppy.js';
 
 export default {
-    input: 'src/guppy.js',
-    output: {name:'Guppy',
-	     file:process.env.NODE_ENV === 'production' ? 'build/guppy.min.js' :( process.env.NODE_ENV === 'test' ? 'build/guppy-test.js' : 'build/guppy.js'),
-	     format: 'umd',
-		 exports: 'default'
-		},
-    plugins: [
-	commonjs({
-            include: [
-                'lib/mousetrap/**',
-                'lib/katex/**'
-            ],
-	    namedExports: { 'mousetrap': ['Mousetrap'] }
-	}),
-	json({
-            include: ['sym/**']
-	}),
-	babel({
-            exclude: 'node_modules/**',
-            presets: [['es2015', { "modules": false }]],
-	    plugins: (process.env.NODE_ENV === 'test' ? [['istanbul', {"include": ['src/**']}]] : [])
-	}),
-	//(process.env.NODE_ENV === 'test' && istanbul({
-	//    include: ['src/**']
-	//})),
-	(process.env.NODE_ENV === 'production' && uglify()),
-    ],
+  input: 'src/guppy.js',
+  output: {
+    name: 'Guppy',
+    file: outputFile,
+    format: 'umd',
+    exports: 'default'
+  },
+  plugins: [
+    commonjs({
+      include: ['lib/mousetrap/**', 'lib/katex/**'],
+      requireReturnsDefault: 'auto'
+    }),
+    json({
+      include: ['sym/**']
+    }),
+    babel({
+      babelHelpers: 'bundled',
+      exclude: 'node_modules/**'
+    }),
+    ...(isProd ? [terser()] : [])
+  ]
 };


### PR DESCRIPTION
…ture

## Overview
This PR updates the Rollup configuration to use maintained plugins and improves code readability.

## Changes Made
- Replaced deprecated plugins with official Rollup plugins
- Simplified environment-based output logic
- Updated Babel configuration to modern standards
- Replaced uglify with terser for better minification
- Improved overall code structure and formatting

## Why is this change needed?
These updates ensure better maintainability, compatibility with modern tooling, and improved build performance.

## Overview
<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #[fill_in_number_here][(fill_in_the_issue_link)].
2. This PR does the following: [Explain here what your PR does and why]
3. (For bug-fixing PRs only) The original bug occurred because: [Explain what
   the cause of the bug was, and which PR introduced it]

## Essential Checklist

- [ ] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [ ] I have followed the build process and "verifying your changes" section mentioned in the [readme file](https://github.com/oppia/guppy/blob/master/README.md).
- [ ] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [ ] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [ ] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [ ] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)


## Proof that changes are correct

<!--
Add videos/screenshots of the running development server with changes you made in the
`package.json` file to test Guppy changes and simultaneously test the interaction that uses Guppy,
first by creating them and then checking them in the preview tab of the exploration editor,
and please keep the developer console open in the meanwhile so that we can be assured
that changes are not causing any errors.

To be specific, your proof video should cover the following points:
 1. `package.json` file with running development server
 2. Creating the interaction while keeping the developer console open.
 3. Previewing the interaction while keeping the developer console open.

When you make updates to the PR, please update these videos/screenshots as well.
You can remove videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g., a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes, then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
