### PR TITLE
Fix #16488: Remove unnecessary parentheses wrapping in fraction asciimath output

### DIFF
--- a/sym/symbols.json
+++ b/sym/symbols.json
@@ -155,7 +155,7 @@
     {"output":{
         "latex":"\\dfrac{{$1}}{{$2}}",
         "small_latex":"\\frac{{$1}}{{$2}}",
-	"asciimath":"({$1})/({$2})"},
+	"asciimath":"{$1}/{$2}"},
      "input":1,
      "keys":["/"],
      "attrs":{


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *all* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes https://github.com/oppia/oppia/issues/16488
2. This PR does the following: Removes the unnecessary parentheses wrapping around the numerator and denominator in the fraction symbol's asciimath output in `sym/symbols.json`.
3. The original bug occurred because `sym/symbols.json` defined the fraction asciimath output as `({$1})/({$2})`, which unconditionally wrapped both numerator and denominator in parentheses. When a user typed an expression like 3(x+12)/4 using the on-screen keyboard on mobile, Guppy would output (3*(x+12))/(4) , the already-parenthesized numerator got double-wrapped, which triggered Oppia's redundant parentheses validator in `math-interactions.service.ts` and incorrectly rejected the answer as invalid.


## Essential Checklist

- [x] The **PR title** starts with "Fix #bugnum: " or "Fix part of #bugnum: ...", followed by a short, clear summary of the changes.
- [x] I have followed the build process and "verifying your changes" section mentioned in the [readme file](https://github.com/oppia/guppy/blob/master/README.md).
- [x] I have followed the [instructions for making a code change](https://github.com/oppia/oppia/wiki/Make-a-pull-request).
- [x] I have assigned the correct reviewers to this PR (or will leave a comment with the phrase "@{{reviewer_username}} PTAL" if I don't have permissions to assign reviewers directly).
- [x] The linter/Karma presubmit checks pass on my local machine, and my PR follows the [coding style guide](https://github.com/oppia/oppia/wiki/Coding-style-guide)).
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)


## Proof that changes are correct

### Before:

https://github.com/user-attachments/assets/11bd50d5-1c8f-4786-8bdb-96509bd408d1

### After:

https://github.com/user-attachments/assets/aed45c45-7d34-4b66-a34b-4cb9559423a8


<!--
Add videos/screenshots of the running development server with changes you made in the
`package.json` file to test Guppy changes and simultaneously test the interaction that uses Guppy,
first by creating them and then checking them in the preview tab of the exploration editor,
and please keep the developer console open in the meanwhile so that we can be assured
that changes are not causing any errors.

To be specific, your proof video should cover the following points:
 1. `package.json` file with running development server
 2. Creating the interaction while keeping the developer console open.
 3. Previewing the interaction while keeping the developer console open.

When you make updates to the PR, please update these videos/screenshots as well.
You can remove videos/screenshots from previous versions of the PR.

The above should be done for all PRs, including short ones (e.g., a single-line change).
However, if the changes in your PRs are autogenerated via a script and you cannot
provide proof for the changes, then please leave a comment "No proof of changes
needed because {{Reason}}" and remove all the sections below.-->

## PR Pointers

- Never force push! If you do, your PR will be closed.
- To reply to reviewers, follow these instructions: https://github.com/oppia/oppia/wiki/Make-a-pull-request#step-5-address-review-comments-until-all-reviewers-approve
- Some e2e tests are flaky, and can fail for reasons unrelated to your PR. We are working on fixing this, but in the meantime, if you need to restart the tests, please check the ["If your build fails" wiki page](https://github.com/oppia/oppia/wiki/If-CI-checks-fail-on-your-PR).
- See the [Code Owner's wiki page](https://github.com/oppia/oppia/wiki/Oppia's-code-owners-and-checks-to-be-carried-out-by-developers) for what code owners will expect.
